### PR TITLE
1.1-update | v1.1 | Added nitro popup and profile nitro ad block

### DIFF
--- a/TemptationBGone.theme.css
+++ b/TemptationBGone.theme.css
@@ -2,7 +2,7 @@
   * @name TemptationBGone
   * @author m-doescode
   * @description Gets rid of the annoying clutter of nitro and inaccessible features. Also gets rid of nitro tempt.
-  * @version 1.0
+  * @version 1.1
 */
 
 
@@ -66,5 +66,15 @@
 
 /* > Hide channel boost notice */
 .channelNotice-7cg_jN {
+	display: none !important;
+}
+
+/* > Hide nitro popup */
+.contentPremium-_Y0-cX {
+	display: none !important;
+}
+
+/* > Hide profile nitro ad */
+.premiumFeatureBorder-3vL7bn.tryItOutSection-W9qeGH {
 	display: none !important;
 }


### PR DESCRIPTION
Removed the popup that appears above the user bar sometimes when you open discord and the nitro advert in the Profiles section of user settings.